### PR TITLE
added support for http uris (useful when in phone)

### DIFF
--- a/src/scripts/support/spotifySupport.js
+++ b/src/scripts/support/spotifySupport.js
@@ -8,6 +8,7 @@ var Support = {},
     Queue,
     templates = require('./spotifyTemplates'),
     trackUriRE = /^spotify:track:[a-z\d]+$/i,
+    trackHttpRE = /^https?:\/\/open\.spotify\.com\/track\/[a-z\d]+$/i,
     currentResultReferenceRE = /^\[?(#|:)?(\d+)\]?$/,
     specificResultReferenceRE = /^\[?(\d+)\]?\[?(#|:)(\d+)\]?/,
     MetaData,
@@ -173,7 +174,7 @@ Support.translateToTrack = function (str, userId, callback) {
         callback(null, new MetaData.Track(results[listItem]));
         return;
     }
-    if (str.match(trackUriRE)) {
+    if (str.match(trackUriRE) || str.match(trackHttpRE)) {
         MetaData.fetchTrack(str, function (err, Track) {
             if (err) {
                 Track = new MetaData.Track({href : str});


### PR DESCRIPTION
when on your phone, the only sharing option results in a `http` uri: `http://open.spotify.com/track/{id}`

This was not tested, however. I need to get this setup local to fully test it but I followed the same pattern for `spotify:track:{id}` uris.
