### PR TITLE
Move convertEmoji call inside findTracks method

### DIFF
--- a/src/scripts/spot.js
+++ b/src/scripts/spot.js
@@ -311,13 +311,6 @@ setVolume = function (level, message) {
     });
 };
 
-var convertEmoji = function (str) {
-    if (str[0] === ':' && str[str.length - 1] === ':') {
-        str = str.replace(/_/g, ' ').replace(/:/g, '');
-    }
-    return str
-};
-
 function setupDefaultQueue(queue, reload, callback) {
     var fs = require('fs');
 
@@ -434,7 +427,7 @@ module.exports = function (robot) {
         return Support.findArtists(message.match[3], message.message.user.id, message.match[2] || DEFAULT_LIMIT, getStrHandler(message));
     });
     robot.respond(/(show|find) (me )?((\d+) )?(music|tracks|songs) (.+)/i, function (message) {
-        return Support.findTracks(convertEmoji(message.match[6]), message.message.user.id, message.match[4] || DEFAULT_LIMIT, getStrHandler(message));
+        return Support.findTracks(message.match[6], message.message.user.id, message.match[4] || DEFAULT_LIMIT, getStrHandler(message));
     });
     robot.respond(/purge results!/i, function (message) {
         Support.purgeLists();

--- a/src/scripts/support/spotifySupport.js
+++ b/src/scripts/support/spotifySupport.js
@@ -62,6 +62,13 @@ function getDataHandler (userId, type, callback) {
     };
 }
 
+function convertEmoji (str) {
+    if (str[0] === ':' && str[str.length - 1] === ':') {
+        str = str.replace(/_/g, ' ').replace(/:/g, '');
+    }
+    return str
+}
+
 Support.translateURItoURL = function (uri) {
     return (uri + '').replace(/spotify:([a-z]+):(.*)$/i, 'https://open.spotify.com/$1/$2');
 };
@@ -341,6 +348,7 @@ Support.playTrack = function (track, callback) {
 Support.findTracks = function (query, userId, limit, callback) {
     var handler = getDataHandler(userId, manager.types.TRACKS, callback),
         aQuery;
+    query = convertEmoji(query);
     if (query.match(/^\s*by\s+(.+)/)) {
         aQuery = RegExp.$1;
         Support.translateToArtist(aQuery, userId, function (err, artist) {
@@ -357,6 +365,7 @@ Support.findTracks = function (query, userId, limit, callback) {
 
 Support.findAlbums = function (query, userId, limit, callback) {
     var handler = getDataHandler(userId, manager.types.ALBUMS, callback);
+    query = convertEmoji(query);
     if (query.match(/^\s*by\s+(.+)/)) {
         Support.translateToArtist(RegExp.$1, userId, function (err, artist) {
             if (err) {
@@ -376,6 +385,7 @@ Support.findAlbums = function (query, userId, limit, callback) {
 };
 
 Support.findArtists = function (query, userId, limit, callback) {
+    query = convertEmoji(query);
     MetaData.findArtists(query, limit, getDataHandler(userId, manager.types.ARTISTS, callback));
 };
 


### PR DESCRIPTION
@andromedado I changed the implementation so that the `convertEmoji` method should get called prior to finding, playing, or queueing anything from spotify. The previous implementation only worked for `find music`
