### PR TITLE
Fix rounding issue with queue length calculation

### DIFF
--- a/src/scripts/support/spotifyTemplates.js
+++ b/src/scripts/support/spotifyTemplates.js
@@ -99,7 +99,7 @@ function calcLength (seconds) {
 
 templates.summarizeQueue = function (tracks) {
     var lines = [asTitle('le Queue')];
-    var queueTimeLeft = 0;
+    var queueLength = 0;
 
     if (!tracks || !tracks.length) {
         lines.push(asAdditional('is empty'));
@@ -107,13 +107,13 @@ templates.summarizeQueue = function (tracks) {
         var i = listIndexBase;
         tracks.forEach(function (track) {
             lines.push(asOrdinal(i) + ' ' + templates.trackLine(track, true));
-            queueTimeLeft += (track.length || 0);
+            if (track.length) {
+                queueLength += parseInt(track.length, 10);
+            }
             i++;
         });
 
-        if (queueTimeLeft > 0) {
-            lines.push('Total Queue time: ' + asDuration(calcLength(queueTimeLeft)));
-        }
+        lines.push('Total Queue time: ' + asDuration(calcLength(queueLength)));
     }
     return lines.join("\n");
 };


### PR DESCRIPTION
I noticed a bug where the total queue time was slightly off from the individual track times. I _think_ it's a rounding issue, due to the fact that the track lengths are parsed individually for display, but being totaled _then_ parsed to calculate total queue time. I'm guessing that some decimal values were causing the discrepancies. Hopefully this PR fixes that. 
