### PR TITLE
Loosen regex to allow spaces in pokemon name

### DIFF
--- a/src/scripts/pokemonfusion.js
+++ b/src/scripts/pokemonfusion.js
@@ -85,7 +85,7 @@ module.exports = function(robot) {
     robot.respond(/lickitung me/i, function (msg) {
         showOnsagerPokemon(msg, lickId, pokedex.fusion.random(lickId), true);
     });
-    robot.respond(/\s(.+)( body)? bomb( (\d+))?/i, function (msg) {
+    robot.respond(/(.+)( body)? bomb( (\d+))?/i, function (msg) {
         var num, w = msg.match[1], id, randId, nots, faceId, bodyId;
         if (w == 'fusion') {
             id = pokedex.fusion.random();

--- a/src/scripts/pokemonfusion.js
+++ b/src/scripts/pokemonfusion.js
@@ -85,7 +85,7 @@ module.exports = function(robot) {
     robot.respond(/lickitung me/i, function (msg) {
         showOnsagerPokemon(msg, lickId, pokedex.fusion.random(lickId), true);
     });
-    robot.respond(/([\S]+)( body)? bomb( (\d+))?/i, function (msg) {
+    robot.respond(/\s(.+)( body)? bomb( (\d+))?/i, function (msg) {
         var num, w = msg.match[1], id, randId, nots, faceId, bodyId;
         if (w == 'fusion') {
             id = pokedex.fusion.random();


### PR DESCRIPTION
This should fix a bug that prevents you from doing a fusion bomb with a pokemon that has spaces in it's name
