### PR TITLE
Make sure speaker type is always lowercase

### DIFF
--- a/src/scripts/sonos.js
+++ b/src/scripts/sonos.js
@@ -265,7 +265,7 @@ module.exports = function(robot) {
 
     function getSpeakerType(match) {
         var type = match || 'main';
-        return type.trim();
+        return type.trim().toLowerCase();
     }
 
     robot.respond(/(.* )?vol(?:ume)?\?/i, function (msg) {


### PR DESCRIPTION
This should fix a bug where trying to get/set the volume of speakers wasn't working when the speaker wasn't all lowercased

cc @CSomerville 😀 
